### PR TITLE
Add UTF encoding to deal with non-ASCII characters

### DIFF
--- a/GalRotpy.py
+++ b/GalRotpy.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
     GalRotpy.py - a Python-based tool for parametrizing galaxy potential by rotation curve
 


### PR DESCRIPTION
This looks like a great tool, great to see this! To get it to work, I had to add the line
```
# -*- coding: utf-8 -*-
```
at the top of the file to deal with the non-ASCII characters in the print statements (see https://www.python.org/dev/peps/pep-0263/). Otherwise I get the error 
```
SyntaxError: Non-ASCII character '\xc3' in file GalRotpy.py on line 369, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```
which might be an issue that other people would also have.